### PR TITLE
feat: add fedi mod injections to api

### DIFF
--- a/packages/ui/src/types/injection/api.ts
+++ b/packages/ui/src/types/injection/api.ts
@@ -10,6 +10,8 @@ export interface FediAPIV0 {
   getAuthenticatedMember(): Promise<AuthenticatedMemberResponse>
   getCurrencyCode: () => Promise<SupportedCurrency>
   getLanguageCode: () => Promise<string>
+  getInstalledFediMods: () => Promise<{ id: string }[]>
+  installFediMod: (mod: InstallFediModArgs) => Promise<void>
 }
 
 export interface FediAPIV1 extends Omit<FediAPIV0, "version"> {
@@ -62,6 +64,8 @@ export interface FediAPILegacy {
   getAuthenticatedMember?: FediAPIV0["getAuthenticatedMember"]
   getCurrencyCode?: FediAPIV0["getCurrencyCode"]
   getLanguageCode?: FediAPIV0["getLanguageCode"]
+  getInstalledFediMods: FediAPIV0["getInstalledFediMods"]
+  installFediMod: FediAPIV0["installFediMod"]
 }
 
 export type RpcCommunity = {
@@ -123,6 +127,14 @@ export interface GenerateEcashArgs {
   defaultAmount?: string | number
   minimumAmount?: string | number
   maximumAmount?: string | number
+}
+
+export interface InstallFediModArgs {
+  name: string
+  id: string
+  url: string,
+  iconUrl: string,
+  description: string,
 }
 
 export type BitcoinNetwork = "signet" | "bitcoin"

--- a/packages/ui/src/types/injection/api.ts
+++ b/packages/ui/src/types/injection/api.ts
@@ -132,7 +132,7 @@ export interface GenerateEcashArgs {
 }
 
 export interface InstallFediModArgs {
-  name: string
+  title: string
   id: string
   url: string,
   iconUrl: string,

--- a/packages/ui/src/types/injection/api.ts
+++ b/packages/ui/src/types/injection/api.ts
@@ -3,6 +3,12 @@ import { SupportedCurrency } from "./currency"
 
 export type FediAPIVersion = (typeof fediAPIVersion)[number]
 
+export interface FediAPIV1 extends Omit<FediAPIV0, 'version'> {
+  version: 1
+  getInstalledFediMods: () => Promise<{ id: string }[]>
+  installFediMod: (mod: InstallFediModArgs) => Promise<void>
+}
+
 export interface FediAPIV0 {
   version: 0
   generateEcash(args: GenerateEcashArgs): Promise<string>
@@ -10,8 +16,6 @@ export interface FediAPIV0 {
   getAuthenticatedMember(): Promise<AuthenticatedMemberResponse>
   getCurrencyCode: () => Promise<SupportedCurrency>
   getLanguageCode: () => Promise<string>
-  getInstalledFediMods: () => Promise<{ id: string }[]>
-  installFediMod: (mod: InstallFediModArgs) => Promise<void>
 }
 
 export interface FediAPIV1 extends Omit<FediAPIV0, "version"> {
@@ -64,8 +68,6 @@ export interface FediAPILegacy {
   getAuthenticatedMember?: FediAPIV0["getAuthenticatedMember"]
   getCurrencyCode?: FediAPIV0["getCurrencyCode"]
   getLanguageCode?: FediAPIV0["getLanguageCode"]
-  getInstalledFediMods: FediAPIV0["getInstalledFediMods"]
-  installFediMod: FediAPIV0["installFediMod"]
 }
 
 export type RpcCommunity = {

--- a/packages/ui/src/types/injection/api.ts
+++ b/packages/ui/src/types/injection/api.ts
@@ -3,12 +3,6 @@ import { SupportedCurrency } from "./currency"
 
 export type FediAPIVersion = (typeof fediAPIVersion)[number]
 
-export interface FediAPIV1 extends Omit<FediAPIV0, 'version'> {
-  version: 1
-  getInstalledFediMods: () => Promise<{ id: string }[]>
-  installFediMod: (mod: InstallFediModArgs) => Promise<void>
-}
-
 export interface FediAPIV0 {
   version: 0
   generateEcash(args: GenerateEcashArgs): Promise<string>
@@ -20,9 +14,11 @@ export interface FediAPIV0 {
 
 export interface FediAPIV1 extends Omit<FediAPIV0, "version"> {
   version: 1
+  getInstalledFediMods: () => Promise<{ url: string }[]>
+  installFediMod: (mod: InstallFediModArgs) => Promise<void>
 }
 
-export interface FediAPIV2 extends Omit<FediAPIV0, "version"> {
+export interface FediAPIV2 extends Omit<FediAPIV1, "version"> {
   version: 2
   listCreatedCommunities: () => Promise<{
     communities: RpcCommunity[]


### PR DESCRIPTION
This PR adds injections for getting a list of installed mods and installing a mod. Our first use case is for adding mods directly from the catalog mod.

One thing I'm not sure of is, I added the new methods to the LegacyAPI so that it would work in the catalog, which expects to work with the legacy version. I'm open to not updating that legacy api and just forcing the catalog to use a new version of the injections API.